### PR TITLE
Use native macOS networking plugins instead of Lima/QEMU VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ Thumbs.db
 
 .vscode/
 .idea/
+
+# Build artifacts
+deps/DL_CACHE/
+resources/i18n/
+tools/slicer_linux_runtime_host/runtime/

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Install and run normally.
 
 ### macOS
 
-Nothing needs to be installed manually.
+Nothing needs to be installed manually. Native macOS networking plugins are downloaded automatically on first use. No VM or Linux runtime is required.
 
-On first use, the application will ask to install the local Linux runtime.
+To force the legacy Linux runtime (Lima/QEMU) instead of native plugins, set `SLICER_LINUX_RUNTIME_MAC_FORCE_LINUX=1` before launching.
 
 ## Removing the runtime
 
@@ -111,7 +111,7 @@ rm -rf ~/.config/BambuStudio_OrcaSlicer ~/.cache/BambuStudio_OrcaSlicer ~/.local
 
 ### macOS
 
-To remove the local Lima runtime:
+Native plugins require no runtime to remove. If you previously used the Lima runtime or have `SLICER_LINUX_RUNTIME_MAC_FORCE_LINUX=1` set:
 
 ```bash
 LIMACTL="$HOME/Library/Application Support/BambuStudio_OrcaSlicer/slicer-linux-runtime/lima/bin/limactl"
@@ -123,6 +123,7 @@ elif command -v limactl >/dev/null 2>&1; then
     limactl delete -f slicer-linux-runtime 2>/dev/null || true
 fi
 rm -rf "$HOME/Library/Application Support/BambuStudio_OrcaSlicer/slicer-linux-runtime"
+unset SLICER_LINUX_RUNTIME_MAC_FORCE_LINUX
 ```
 
 ## What was done
@@ -130,7 +131,8 @@ rm -rf "$HOME/Library/Application Support/BambuStudio_OrcaSlicer/slicer-linux-ru
 * Updated to OrcaSlicer as of June 14, 2026, up to commit [`9bcee518f859205fbcf3455c4f89fce5c606049c`](https://github.com/SoftFever/OrcaSlicer/commit/9bcee518f859205fbcf3455c4f89fce5c606049c) + added OrcaSlicer commits [`e700113b39f39b837175c680929538aa9655a9f9`](https://github.com/SoftFever/OrcaSlicer/commit/e700113b39f39b837175c680929538aa9655a9f9) and [`5ed8f5ef258898a4006677bab8a3f2e412adedec`](https://github.com/SoftFever/OrcaSlicer/commit/5ed8f5ef258898a4006677bab8a3f2e412adedec).
 * Restored BambuNetwork support through the Linux `bambu_networking` path.
 * Added Windows WSL2 runtime support.
-* Added macOS Lima runtime support.
+* Added native macOS networking plugin support (no VM required).
+* Legacy Lima/QEMU runtime still available via `SLICER_LINUX_RUNTIME_MAC_FORCE_LINUX=1`.
 * Fixed macOS runtime integration, including printer connection, file browsing and camera preview.
 * Added experimental Bambu Lab A2L printer support - it has not been tested.
 * Fixed the issue that appears when using BMCU with A1 / A1-mini printers on firmware `01.08.01.00` and `01.08.00.00`.

--- a/build_release_macos.sh
+++ b/build_release_macos.sh
@@ -99,7 +99,7 @@ if [ -z "$OSX_DEPLOYMENT_TARGET" ]; then
 fi
 
 if [ -z "$CMAKE_IGNORE_PREFIX_PATH" ]; then
-  export CMAKE_IGNORE_PREFIX_PATH="/opt/local:/usr/local:/opt/homebrew"
+  export CMAKE_IGNORE_PREFIX_PATH="/opt/local:/usr/local:/opt/homebrew:/nix/store:/nix"
 fi
 
 is_gnu_m4() {

--- a/src/slic3r/Utils/SlicerLinuxRuntime/SlicerLinuxRuntimeConfig.cpp
+++ b/src/slic3r/Utils/SlicerLinuxRuntime/SlicerLinuxRuntimeConfig.cpp
@@ -107,7 +107,12 @@ bool enabled()
 #if defined(_MSC_VER) || defined(_WIN32)
     return true;
 #elif defined(__WXMAC__) || defined(__APPLE__)
-    return true;
+    // macOS uses native plugins; Lima runtime is unnecessary.
+    // Allow override via env var for debugging.
+    bool force_enable = false;
+    if (env_flag("SLICER_LINUX_RUNTIME_MAC_FORCE_ENABLE", force_enable) && force_enable)
+        return true;
+    return false;
 #else
     return false;
 #endif

--- a/src/slic3r/Utils/SlicerLinuxRuntime/SlicerLinuxRuntimeConfig.cpp
+++ b/src/slic3r/Utils/SlicerLinuxRuntime/SlicerLinuxRuntimeConfig.cpp
@@ -118,7 +118,14 @@ bool use_linux_runtime()
 #if defined(_MSC_VER) || defined(_WIN32)
     return true;
 #elif defined(__WXMAC__) || defined(__APPLE__)
-    return true;
+    // macOS has native .dylib plugins served by the Bambu API when
+    // X-BBL-OS-Type is set to "macos". The Linux runtime (Lima/QEMU VM)
+    // is unnecessary and causes significant CPU overhead from x86 emulation.
+    // Only force the Linux runtime if explicitly requested via env var.
+    bool force_linux = false;
+    if (env_flag("SLICER_LINUX_RUNTIME_MAC_FORCE_LINUX", force_linux) && force_linux)
+        return true;
+    return false;
 #else
     return false;
 #endif

--- a/tools/slicer_linux_runtime/macos/install_runtime_macos.sh
+++ b/tools/slicer_linux_runtime/macos/install_runtime_macos.sh
@@ -317,7 +317,7 @@ select_lima_mode() {
     LIMA_CREATE_ARGS=(start "--name=${INSTANCE}" --tty=false --mount-writable --containerd=none)
 
     if [[ "$host_arch" == "arm64" ]]; then
-        if [[ "$major" -ge 13 && "${SLICER_LINUX_RUNTIME_MAC_USE_ROSETTA:-}" == "1" && portable_x86_loader_available ]]; then
+        if [[ "$major" -ge 13 && "${SLICER_LINUX_RUNTIME_MAC_NO_ROSETTA:-}" != "1" && portable_x86_loader_available ]]; then
             LIMA_MODE="vz-aarch64-rosetta"
             LIMA_CREATE_ARGS+=(--vm-type=vz --arch=aarch64 --mount-type=virtiofs --rosetta)
         else


### PR DESCRIPTION
## Summary

Bambu Lab's API serves native `.dylib` plugins for macOS. However, `use_linux_runtime()` was hardcoded to return `true` on `__APPLE__`, forcing the app to run x86 Linux `.so` files inside a Lima QEMU VM with TCG software emulation.

The code already has a native macOS path in `BBLNetworkPlugin.cpp` that calls `dlopen("libbambu_networking_<version>.dylib")` when `linux_runtime` is false. It just never gets reached.

Closes #9